### PR TITLE
add .path property to a module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function ModulesProvider(context, execution, controller) {
       return contextModules[pathKey]
     }, contextModules)
     module.meta = modules[key].meta
+    module.path = modulePath;
     module.state = context.state.select(modulePath)
     module.services = modulePath.reduce(function (services, key) {
       return services[key] || {}


### PR DESCRIPTION
I may be missing something, but I can't seem to access the path of a module referenced by alias from within an action context. 
